### PR TITLE
Feature/static dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ import org.gradle.api.artifacts.maven.MavenDeployment
 // Settings
 ext {
     project_group = 'com.github.rholder'
-    project_version = '2.0.0'
+    project_version = '2.0.1'
     project_jdk = '1.6'
     project_pom = {
         name 'guava-retrying'

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.google.guava:guava:[10.+,)'
+    compile 'com.google.guava:guava:20.0'
     compile 'com.google.code.findbugs:jsr305:2.0.2'
 
     // junit testing


### PR DESCRIPTION
Make guava dependency version 20.0 for support java 1.6+ (not only java 1.8)